### PR TITLE
Refactor/array,undefined,set data

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+# Summary
+
+- 제목
+- 프로덕트 스펙
+- 테크 스펙
+- 기타 링크
+
+  <br />
+
+# Changes
+
+- (변경 사항)
+
+<br/>
+
+# Screenshot
+
+<img src="파일주소" width="50%" height="50%" alt="스크린샷" />
+
+<br/>
+
+# Test Checklist
+
+- [ ] (확인할 테스트)
+
+<br/>

--- a/deepCopy/index.js
+++ b/deepCopy/index.js
@@ -28,8 +28,8 @@ const deepCopy = (data) => {
   if (data instanceof Set) {
     const newSet = new Set();
 
-    for (const key of Object.keys(data)) {
-      newSet.add(key);
+    for (const item of data) {
+      newSet.add(deepCopy(item));
     }
 
     return newSet;

--- a/deepCopy/index.js
+++ b/deepCopy/index.js
@@ -6,7 +6,13 @@ const deepCopy = (data) => {
   }
 
   if (Array.isArray(data)) {
-    return [...data];
+    const newArr = [];
+
+    for (const [index, value] of Object.entries(data)) {
+      newArr[index] = deepCopy(value);
+    }
+
+    return newArr;
   }
 
   if (data instanceof Map) {

--- a/deepCopy/index.js
+++ b/deepCopy/index.js
@@ -1,5 +1,5 @@
 const deepCopy = (data) => {
-  if (data === null) return data;
+  if (!data) return data;
 
   if (typeof data !== "object") {
     return data;

--- a/deepCopy/index.spec.js
+++ b/deepCopy/index.spec.js
@@ -47,7 +47,7 @@ describe("deepCopy 함수 테스트", () => {
   });
 
   it("배열 데이터를 인자로 넘겨 반환된 배열은 원본과 달라야 한다.", () => {
-    const c = [1, 2, 3];
+    const c = [1, 2, [2, 3]];
     const d = c;
     const copiedArr = deepCopy(d);
 
@@ -59,6 +59,11 @@ describe("deepCopy 함수 테스트", () => {
 
     expect(c[0] === 4).toBe(true);
     expect(copiedArr[0] === 4).toBe(false);
+
+    d[2][0] = 1;
+
+    expect(c[2][0] === 1).toBe(true);
+    expect(copiedArr[2][0] === 1).toBe(false);
   });
 
   it("맵 데이터를 인자로 넘겨 반환된 데이터는 원본과 달라야 한다.", () => {

--- a/deepCopy/index.spec.js
+++ b/deepCopy/index.spec.js
@@ -79,6 +79,7 @@ describe("deepCopy 함수 테스트", () => {
 
     expect(map === map2).toBe(true);
     expect(map === copiedMap).toBe(false);
+    expect(JSON.stringify(map) === JSON.stringify(copiedMap)).toBe(true);
     expect(map instanceof Map).toBe(true);
     expect(copiedMap instanceof Map).toBe(true);
 
@@ -95,6 +96,7 @@ describe("deepCopy 함수 테스트", () => {
 
     expect(set === set2).toBe(true);
     expect(set === copiedSet).toBe(false);
+    expect(JSON.stringify(set) === JSON.stringify(copiedSet)).toBe(true);
     expect(set instanceof Set).toBe(true);
     expect(copiedSet instanceof Set).toBe(true);
 

--- a/deepCopy/index.spec.js
+++ b/deepCopy/index.spec.js
@@ -6,6 +6,8 @@ describe("deepCopy 함수 테스트", () => {
     expect(deepCopy("1") === "1").toBe(true);
     expect(deepCopy(true) === true).toBe(true);
     expect(deepCopy(null) === null).toBe(true);
+    expect(deepCopy() === undefined).toBe(true);
+    expect(deepCopy(undefined) === undefined).toBe(true);
   });
 
   it("객체 데이터를 인자로 넘겨 반환된 객체는 원본과 달라야 한다.", () => {


### PR DESCRIPTION
# Summary

- Array, Set, Undefined 데이터에 대한 메서드 수정 및 기능을 추가했습니다.

  <br />

# Changes

- 인자가 배열일 경우 요소가 참조형 데이터일 경우를 반영해, 배열의 요소들을 재귀로 깊은 복사를 실행하여 반환하도록 수정했습니다.
- 인자가 undefined일 경우까지 처리하도록 종료문의 유효성 검사를 수정했습니다.
- 인자가 set일 경우 키를 지정할 때 재귀로 깊은 복사를 실행하여 새로운 set을 반환하도록 수정했습니다.
- 인자가 set일 경우 기존에 데이터가 복사되지 않는 오류 부분을 수정했습니다.

<br/>

# Test Checklist
- [x]  배열의 요소가 참조형 데이터이고 참조형 데이터를 변경 했을때 테스트 추가
- [x] undefined이 인자로 들어오거나, 빈 인자로 실행했을 때 테스트 추가
- [x] deepCopy 테스트가 값은 같고, 메모리가 다른지에 대한 테스트 추가

<br/>